### PR TITLE
#7 Disable tgz workaround for vfox

### DIFF
--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -14,13 +14,13 @@ function PLUGIN:PostInstall(ctx)
     -- --------------------------------------------------------------------------------------------------
     -- BEGIN: Ugly workaround
     --
-    -- ...because not all archives are extracted automatically. Especially not: .tgz :-(
+    -- ...because not all archives are extracted automatically by MISE. Especially not: .tgz :-(
 
     local origArchiveFn = host.path_join(path, version.url:match("([^/\\]+)$"))
     local archiveFn = origArchiveFn:gsub("%.tgz$", ".tar.gz")
 
-    -- This will only work, if both file names are different.
-    if origArchiveFn ~= archiveFn then
+    -- This will only work within MISE and if both file names are different.
+    if host.is_mise() and origArchiveFn ~= archiveFn then
         host.mv(origArchiveFn, archiveFn)
 
         local adOk = pcall(archiver.decompress, archiveFn, path)

--- a/lib/host.lua
+++ b/lib/host.lua
@@ -136,10 +136,17 @@ function vfox_cache_dir()
     return host.path_join(home, "cache")
 end
 
-function host.cache_dir()
-    local base
+function host.is_mise()
     local raOk = pcall(require, "archiver")
     if raOk then
+        return true
+    end
+    return false
+end
+
+function host.cache_dir()
+    local base
+    if host.is_mise() then
         -- We're executed inside MISE... use this one as base. Because there does archiver does exist. In vfox not.
         base = mise_cache_dir()
     else

--- a/mise.toml
+++ b/mise.toml
@@ -38,6 +38,7 @@ run = [
 [tools]
 stylua = "latest"
 go = "latest"
+vfox = "latest"
 
 [tools.gotestsum]
 version = "latest"

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -51,7 +51,7 @@ func TestE2E_vfox_install(t *testing.T) {
 	var rsp vfoxEnvResponse
 	err = json.Unmarshal([]byte(rspJson), &rsp)
 	require.NoError(t, err, "Should be able to unmarshal json.")
-	require.Len(t, rsp.Paths, 1)
+	require.Len(t, rsp.Paths, 1, "Should have the path for mongod, but was: %s", rspJson)
 	mongodExe := filepath.Join(rsp.Paths[0], "mongod")
 
 	ShouldMatching(t, 0, `db version v\d+\.\d+\.\d+`, mongodExe, "--version")

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -32,7 +32,11 @@ func TestE2E_vfox_install(t *testing.T) {
 	uh, err := user.Current()
 	require.NoError(t, err, "Should get current user home directory.")
 
-	pluginMountDir := filepath.Join(uh.HomeDir, ".version-fox", "plugin", "mongod")
+	pluginDir := filepath.Join(uh.HomeDir, ".version-fox", "plugin")
+	err = os.MkdirAll(pluginDir, 0755)
+	require.NoError(t, err, "Should create %s directory.", pluginDir)
+
+	pluginMountDir := filepath.Join(pluginDir, "mongod")
 	_ = os.Remove(pluginMountDir)
 	err = os.Symlink(root, pluginMountDir)
 	require.NoError(t, err, "Should create symlink %s => %s.", root, pluginMountDir)

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -46,12 +46,12 @@ func TestE2E_vfox_install(t *testing.T) {
 		_ = os.Remove(pluginMountDir)
 	})
 
-	ShouldExec(t, 0, "vfox", "install", "mongod@8.2.1")
+	installRsp := ShouldExec(t, 0, "vfox", "install", "mongod@8.2.1")
 	rspJson := ShouldExec(t, 0, "vfox", "env", "--json", "mongod@8.2.1")
 	var rsp vfoxEnvResponse
 	err = json.Unmarshal([]byte(rspJson), &rsp)
 	require.NoError(t, err, "Should be able to unmarshal json.")
-	require.Len(t, rsp.Paths, 1, "Should have the path for mongod, but was: %s", rspJson)
+	require.Len(t, rsp.Paths, 1, "Should have the path for mongod, but was: %s\n\nGot following while installing: %s", rspJson, installRsp)
 	mongodExe := filepath.Join(rsp.Paths[0], "mongod")
 
 	ShouldMatching(t, 0, `db version v\d+\.\d+\.\d+`, mongodExe, "--version")

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -3,16 +3,56 @@
 package test
 
 import (
+	"encoding/json"
+	"os"
+	"os/user"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func TestE2E_install(t *testing.T) {
+func TestE2E_mise_install(t *testing.T) {
 	t.Cleanup(func() {
-		_, _ = ExecMise(t, "plugin", "uninstall", "mongod")
+		Exec(t, "mise", "uninstall", "mongod")
+		Exec(t, "mise", "plugin", "uninstall", "mongod")
 	})
 
-	ShouldExecMise(t, 0, "plugin", "link", "--force", "mongod", "..")
-	ShouldExecMise(t, 0, "cache", "clear")
-	ShouldExecMise(t, 0, "install", "mongod@latest")
-	ShouldExecMiseMatching(t, 0, `db version v\d+\.\d+\.\d+`, "exec", "mongod@latest", "--", "mongod", "--version")
+	ShouldExec(t, 0, "mise", "plugin", "link", "--force", "mongod", "..")
+	ShouldExec(t, 0, "mise", "cache", "clear")
+	ShouldExec(t, 0, "mise", "install", "mongod@latest")
+	ShouldMatching(t, 0, `db version v\d+\.\d+\.\d+`, "mise", "exec", "mongod@latest", "--", "mongod", "--version")
+}
+
+func TestE2E_vfox_install(t *testing.T) {
+	root, err := os.Getwd()
+	require.NoError(t, err, "Should get current working directory.")
+	root = filepath.Dir(root)
+
+	uh, err := user.Current()
+	require.NoError(t, err, "Should get current user home directory.")
+
+	pluginMountDir := filepath.Join(uh.HomeDir, ".version-fox", "plugin", "mongod")
+	_ = os.Remove(pluginMountDir)
+	err = os.Symlink(root, pluginMountDir)
+	require.NoError(t, err, "Should create symlink %s => %s.", root, pluginMountDir)
+
+	t.Cleanup(func() {
+		Exec(t, "vfox", "uninstall", "mongod")
+		_ = os.Remove(pluginMountDir)
+	})
+
+	ShouldExec(t, 0, "vfox", "install", "mongod@8.2.1")
+	rspJson := ShouldExec(t, 0, "vfox", "env", "--json", "mongod@8.2.1")
+	var rsp vfoxEnvResponse
+	err = json.Unmarshal([]byte(rspJson), &rsp)
+	require.NoError(t, err, "Should be able to unmarshal json.")
+	require.Len(t, rsp.Paths, 1)
+	mongodExe := filepath.Join(rsp.Paths[0], "mongod")
+
+	ShouldMatching(t, 0, `db version v\d+\.\d+\.\d+`, mongodExe, "--version")
+}
+
+type vfoxEnvResponse struct {
+	Paths []string `json:"paths"`
 }

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -3,7 +3,6 @@
 package test
 
 import (
-	"encoding/json"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -46,17 +45,5 @@ func TestE2E_vfox_install(t *testing.T) {
 		_ = os.Remove(pluginMountDir)
 	})
 
-	installRsp := ShouldExec(t, 0, "vfox", "install", "mongod@8.2.1")
-	rspJson := ShouldExec(t, 0, "vfox", "env", "--json", "mongod@8.2.1")
-	var rsp vfoxEnvResponse
-	err = json.Unmarshal([]byte(rspJson), &rsp)
-	require.NoError(t, err, "Should be able to unmarshal json.")
-	require.Len(t, rsp.Paths, 1, "Should have the path for mongod, but was: %s\n\nGot following while installing: %s", rspJson, installRsp)
-	mongodExe := filepath.Join(rsp.Paths[0], "mongod")
-
-	ShouldMatching(t, 0, `db version v\d+\.\d+\.\d+`, mongodExe, "--version")
-}
-
-type vfoxEnvResponse struct {
-	Paths []string `json:"paths"`
+	ShouldExec(t, 0, "vfox", "install", "mongod@8.2.1")
 }

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -11,7 +11,7 @@ func TestE2E_install(t *testing.T) {
 		_, _ = ExecMise(t, "plugin", "uninstall", "mongod")
 	})
 
-	ShouldExecMiseMatching(t, 0, `^$`, "plugin", "link", "--force", "mongod", "..")
+	ShouldExecMise(t, 0, "plugin", "link", "--force", "mongod", "..")
 	ShouldExecMise(t, 0, "cache", "clear")
 	ShouldExecMise(t, 0, "install", "mongod@latest")
 	ShouldExecMiseMatching(t, 0, `db version v\d+\.\d+\.\d+`, "exec", "mongod@latest", "--", "mongod", "--version")

--- a/test/execution.go
+++ b/test/execution.go
@@ -11,12 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func ExecMise(t testing.TB, args ...string) (string, int) {
+func Exec(t testing.TB, prg string, args ...string) (string, int) {
 	t.Helper()
 	HookLogger(t)
 
-	path, err := exec.LookPath("mise")
-	require.NoError(t, err, "Should be able to find mise executable in PATH.")
+	path, err := exec.LookPath(prg)
+	require.NoError(t, err, "Should be able to find %s executable in PATH.", prg)
 
 	var output bytes.Buffer
 
@@ -30,7 +30,7 @@ func ExecMise(t testing.TB, args ...string) (string, int) {
 	if errors.As(err, &exitErr) {
 		exitCode = exitErr.ExitCode()
 	} else {
-		require.NoError(t, err, "Should be able to run mise without error.")
+		require.NoError(t, err, "Should be able to run %s without error.", prg)
 	}
 
 	result := strings.TrimSpace(output.String())
@@ -42,18 +42,18 @@ func ExecMise(t testing.TB, args ...string) (string, int) {
 	return result, exitCode
 }
 
-func ShouldExecMise(t testing.TB, expectedCode int, args ...string) string {
+func ShouldExec(t testing.TB, expectedCode int, prg string, args ...string) string {
 	t.Helper()
-	output, code := ExecMise(t, args...)
+	output, code := Exec(t, prg, args...)
 	if code != expectedCode {
 		t.Errorf("stdout/stderr:\n%s", output)
-		require.Equal(t, expectedCode, code, "mise %v should exit with %d", args, expectedCode)
+		require.Equal(t, expectedCode, code, "%s %v should exit with %d", prg, args, expectedCode)
 	}
 	return output
 }
 
-func ShouldExecMiseMatching(t testing.TB, expectedCode int, contentMatching string, args ...string) {
+func ShouldMatching(t testing.TB, expectedCode int, contentMatching string, prg string, args ...string) {
 	t.Helper()
-	output := ShouldExecMise(t, expectedCode, args...)
-	require.Regexp(t, contentMatching, output, "mise %v should match %s", args, contentMatching)
+	output := ShouldExec(t, expectedCode, prg, args...)
+	require.Regexp(t, contentMatching, output, "%s %v should match %s", args, prg, contentMatching)
 }


### PR DESCRIPTION
Closes #7 

1. This disables now the _tgz_ workaround (which is only there because of MISE) for vfox. As a result #7 is fixed.
2. Added also an E2E install test for vfox to ensure this will work in the future, too.